### PR TITLE
Fix the snippet loading with Babel ES6 JavaScript

### DIFF
--- a/snippets/assertions.json
+++ b/snippets/assertions.json
@@ -1,5 +1,5 @@
 {
-	".source.js, .source.jsx, .source.ts": {
+	".source.js, .source.js.jsx, .source.jsx, .source.ts": {
 		"t.pass()": {
 			"prefix": "t.pass",
 			"body": "t.pass(${1:'${2:message}'});"

--- a/snippets/ava.json
+++ b/snippets/ava.json
@@ -1,5 +1,5 @@
 {
-	".source.js, .source.jsx, .source.ts": {
+	".source.js, .source.js.jsx, .source.jsx, .source.ts": {
 		"AVA": {
 			"prefix": "ava",
 			"body": "import test from 'ava';\nimport $1 from '$2';\n\ntest('${3:title}', t => {\n\tt.is($1(), '$4');\n});"


### PR DESCRIPTION
When using Babel ES6 JavaScript as syntax, the source is considered as `source.js.jsx` and with current definition, the snippet is not loaded/used. This change set fixes the issue.
