### PR TITLE
Add error notification when ava is not found

### DIFF
--- a/lib/terminal-command-executor.js
+++ b/lib/terminal-command-executor.js
@@ -39,6 +39,12 @@ class TerminalCommandExecutor extends EventEmitter {
 	}
 
 	_streamClosed(code) {
+		if (code === 127) {
+			atom.notifications.addError('[ava] Command not found', {
+				detail: 'ava was not found, make sure it is installed. You may need to install it globally',
+				dismissable: true
+			});
+		}
 		this.emit(this.dataFinishedEventName, code);
 	}
 }


### PR DESCRIPTION
This will appear if the command returns command not found.
<img width="470" alt="screen shot 2016-05-18 at 07 20 58" src="https://cloud.githubusercontent.com/assets/476364/15348229/2fdc39ba-1cc9-11e6-91e5-039ffe0be03f.png">
