### PR TITLE
prefer local ava if available, fallback to global

### DIFF
--- a/lib/test-runner-process.js
+++ b/lib/test-runner-process.js
@@ -1,7 +1,10 @@
 /** @babel */
+
+import fs from 'fs';
 import EventEmitter from 'events';
-import TerminalCommandExecutor from './terminal-command-executor';
+
 import ParserFactory from './parser-factory';
+import TerminalCommandExecutor from './terminal-command-executor';
 
 class TestRunnerProcess extends EventEmitter {
 	constructor(
@@ -37,9 +40,16 @@ class TestRunnerProcess extends EventEmitter {
 		this.parser = this.parserFactory.getParser();
 		this._setHandlersOnParser(this.parser);
 
-		const command = `ava ${file} --tap`;
+		const ava = this._getAvaInstance();
+		const command = `${ava} ${file} --tap`;
 
 		this.terminalCommandExecutor.run(command, folder);
+	}
+
+	_getAvaInstance() {
+		const localPath = 'node_modules/.bin/ava';
+
+		return fs.existsSync(localPath) ? localPath : 'ava';
 	}
 
 	_setHandlersOnParser(parser) {

--- a/spec/test-runner-process-spec.js
+++ b/spec/test-runner-process-spec.js
@@ -1,8 +1,11 @@
 /** @babel */
+
+import fs from 'fs';
 import EventEmitter from 'events';
-import TestRunnerProcess from '../lib/test-runner-process';
-import TerminalCommandExecutor from '../lib/terminal-command-executor';
+
 import ParserFactory from '../lib/parser-factory';
+import TerminalCommandExecutor from '../lib/terminal-command-executor';
+import TestRunnerProcess from '../lib/test-runner-process';
 
 class FakeParser extends EventEmitter {
 	constructor() {
@@ -45,7 +48,16 @@ describe('TestRunnerProcess', () => {
 
 	it('can be created', () => expect(runner).not.toBeNull());
 
+	it('runs the executor with a local ava instance if possible', () => {
+		spyOn(fs, 'existsSync').andReturn(true);
+		spyOn(atom.project, 'getPaths').andReturn(['path']);
+		spyOn(executor, 'run');
+		runner.run('/somefolder/', 'filename');
+		expect(executor.run).toHaveBeenCalledWith('node_modules/.bin/ava filename --tap', '/somefolder/');
+	});
+
 	it('runs the executor with the appropriate parameters', () => {
+		spyOn(fs, 'existsSync').andReturn(false);
 		spyOn(atom.project, 'getPaths').andReturn(['path']);
 		spyOn(executor, 'run');
 		runner.run('/somefolder/', 'filename');


### PR DESCRIPTION
If ava is installed as a module, use this over the globally installed instance.
An improvement on this PR would be to even add this as an option in the plugin UI. Fixes #19

I am not quite sure if spying on `fs.existsSync` is the proper way to implement the test for this. I am open for suggestions.
