### PR TITLE
Falls back to the global project should editor not have one.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ module.exports = {
 
 		const editor = atom.workspace.getActiveTextEditor();
 		const currentFileName = editor.getPath();
-		const paths = editor.project.getPaths();
+		const paths = (editor.project || atom.project).getPaths();
 		const selectedProject = paths.filter(p => currentFileName.startsWith(p));
 
 		this.panel.renderStartProcess();


### PR DESCRIPTION
Seemingly, `editor.project` is not a thing?  

Tested on Atom 1.9.5 (darwin) but not 1.10-beta2.

Addresses: https://github.com/avajs/atom-ava/issues/22
