### PR TITLE
Use new Atom Docks API

### DIFF
--- a/lib/ava-panel.js
+++ b/lib/ava-panel.js
@@ -3,20 +3,36 @@ import path from 'path';
 import fs from 'fs';
 import HtmlRendererHelper from './html-renderer-helper';
 
-export default class Panel {
-	constructor(pluginInstance, htmlRendererHelper = new HtmlRendererHelper()) {
+export default class AvaPanel {
+	constructor(htmlRendererHelper = new HtmlRendererHelper()) {
 		this.htmlRendererHelper = htmlRendererHelper;
-		this.pluginInstance = pluginInstance;
 		this.loadingSelector = 'sk-three-bounce';
+	}
+
+	getTitle() {
+		return 'AVA';
+	}
+
+	getURI() {
+		return 'atom://ava/runner';
+	}
+
+	getDefaultLocation() {
+		return 'right';
+	}
+
+	getAllowedLocations() {
+		return ['left', 'right'];
+	}
+
+	getPreferredWidth() {
+		return 350;
 	}
 
 	renderBase() {
 		this.element = document.createElement('div');
 		this.element.classList.add('ava');
 		this.element.innerHTML = fs.readFileSync(path.resolve(__dirname, '../views/panel.html'));
-		const closeIcon = this.element.getElementsByClassName('close-icon')[0];
-		closeIcon.addEventListener('click', () => this.pluginInstance.hidePanel());
-
 		this.groupsContainer = this.element.getElementsByClassName('tests-groups-container')[0];
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,17 +14,7 @@ export default {
 		this.subscriptions.add(
 			atom.commands.add('atom-workspace', 'ava:run-file', () => this.run()),
 			atom.commands.add('atom-workspace', 'ava:run', () => this.runAll()),
-			atom.commands.add('atom-workspace', 'core:cancel', ev => this.handleClosePanel(ev))
 		);
-	},
-	handleClosePanel({target}) {
-		const isFocusOnEditor = target.tagName && 'ATOM-TEXT-EDITOR' && !target.hasAttribute('mini');
-		if (isFocusOnEditor) {
-			this.hidePanel();
-		}
-	},
-	hidePanel() {
-		atom.workspace.hide(this.panel);
 	},
 	initRunnerProcess() {
 		this.testRunnerProcess = new TestRunnerProcess();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /** @babel */
 import path from 'path';
 import {CompositeDisposable} from 'atom';
-import Panel from './panel';
+import AvaPanel from './ava-panel';
 import TestRunnerProcess from './test-runner-process';
 
 export default {
@@ -19,12 +19,12 @@ export default {
 	},
 	handleClosePanel({target}) {
 		const isFocusOnEditor = target.tagName && 'ATOM-TEXT-EDITOR' && !target.hasAttribute('mini');
-		if (isFocusOnEditor && this.atomPanel.isVisible()) {
+		if (isFocusOnEditor) {
 			this.hidePanel();
 		}
 	},
 	hidePanel() {
-		this.atomPanel.hide();
+		atom.workspace.hide(this.panel);
 	},
 	initRunnerProcess() {
 		this.testRunnerProcess = new TestRunnerProcess();
@@ -32,20 +32,18 @@ export default {
 		this.testRunnerProcess.on('complete', results => this.panel.renderFinalReport(results));
 	},
 	initUI() {
-		this.panel = new Panel(this);
+		this.panel = new AvaPanel();
 		this.panel.renderBase();
-		this.atomPanel = atom.workspace.addRightPanel({
-			item: this.panel,
-			visible: false
-		});
+		this.openItem();
+	},
+	openItem() {
+		atom.workspace.open(this.panel);
 	},
 	canRun() {
 		return atom.workspace.getActiveTextEditor() && this.testRunnerProcess.canRun();
 	},
 	run() {
-		if (!this.atomPanel.isVisible()) {
-			this.atomPanel.show();
-		}
+		this.openItem();
 
 		if (!this.canRun()) {
 			return;
@@ -60,9 +58,7 @@ export default {
 		this.testRunnerProcess.run(folder, file);
 	},
 	runAll() {
-		if (!this.atomPanel.isVisible()) {
-			this.atomPanel.show();
-		}
+		this.openItem();
 
 		if (!this.canRun()) {
 			return;

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -1,4 +1,23 @@
 /** @babel */
+import AvaPanel from '../lib/ava-panel';
+
+const getDockGivenDefault = () => {
+	const panel = new AvaPanel();
+	const defaultLocation = panel.getDefaultLocation();
+
+	const workspace = atom.workspace;
+
+	switch (defaultLocation) {
+		case 'center':
+			return workspace.getCenter();
+		case 'left':
+			return workspace.getLeftDock();
+		case 'right':
+			return workspace.getRightDock();
+		default:
+			return workspace.getBottomDock();
+	}
+};
 
 describe('TestingForAva', () => {
 	const packageName = 'ava';
@@ -32,10 +51,11 @@ describe('TestingForAva', () => {
 			waitsForPromise(() => activationPromise);
 
 			runs(() => {
-				const mainElement = workspaceElement.querySelector(mainSelector);
-				expect(mainElement).toBeVisible();
+				const dock = getDockGivenDefault();
+				expect(dock.isVisible()).toBeTruthy();
+
 				atom.commands.dispatch(workspaceElement, 'core:cancel');
-				expect(mainElement).not.toBeVisible();
+				expect(dock.isVisible()).toBeFalsy();
 			});
 		});
 	});

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -53,9 +53,6 @@ describe('TestingForAva', () => {
 			runs(() => {
 				const dock = getDockGivenDefault();
 				expect(dock.isVisible()).toBeTruthy();
-
-				atom.commands.dispatch(workspaceElement, 'core:cancel');
-				expect(dock.isVisible()).toBeFalsy();
 			});
 		});
 	});

--- a/styles/ava.less
+++ b/styles/ava.less
@@ -2,7 +2,7 @@
 @import 'loading-indicator.less';
 
 .ava {
-	width: 350px;
+	width: 100%;
 	font-size: 15px;
 	overflow: scroll;
 
@@ -19,6 +19,7 @@
 	}
 
 	.ava-logo-container {
+		padding-top: 15px;
 		text-align: center;
 
 		.ava-logo-image {

--- a/styles/ava.less
+++ b/styles/ava.less
@@ -6,14 +6,6 @@
 	font-size: 15px;
 	overflow: scroll;
 
-	.close-icon {
-		text-align: right;
-		margin-right: 10px;
-		margin-top: 10px;
-		font-size: 16px;
-		cursor: pointer;
-	}
-
 	.group-header {
 		background-color: @tab-bar-background-color;
 		color: #888;

--- a/views/panel.html
+++ b/views/panel.html
@@ -1,4 +1,3 @@
-<div class="close-icon">✖</div>
 <div class="ava-logo-container">
 	<img class="ava-logo-image" src="atom://ava/media/logo.png">
 </div>


### PR DESCRIPTION
Hi folks!

This is a proposal to add the new Docks API to the package as per [this](https://github.com/avajs/atom-ava/issues/26) issue.

Basically, **this is the change from the old pane to the new API, removing the UI that we had to close the runner** (the Docks provide the logic required to do this, so packages don't implement it themselves). 

Most of the logic that controls the default values has been pushed to the (old) Panel class that acts as a view. As with the new Docks API is possible to have multiple panes in the same dock, I have renamed the class from Panel to AvaPanel as it may be useful to identify the class in an Array (by type).

For consistency and as the UI was already prepared to be shown on the right side of the editor, I have constrained the possible options to just 'left' and 'right' keeping 'right' as the default.

We still [have a feature](https://github.com/avajs/atom-ava/blob/master/lib/index.js#L20) that allows the user to close the pane by clicking `ESC`/`core:cancel` when the editor is focused. I wonder if maybe we should get rid completely of this behavior and allow the pane to be closed naturally with `CMD-W`.

Cheers!

Note: Once the package has been activated and the UI rearranged in some way (moved, resized) these values will override the default. To recover the defaults, this command can be executed:

`atom --clear-window-state`

---

Fixes #26 