### PR TITLE
Use project AVA when available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,11 +56,10 @@ export default {
 
 		const editor = atom.workspace.getActiveTextEditor();
 		const currentFileName = editor.getPath();
-		const paths = (editor.project || atom.project).getPaths();
-		const selectedProject = paths.filter(p => currentFileName.startsWith(p));
+		const folder = path.dirname(currentFileName);
 
 		this.panel.renderStartProcess();
-		this.testRunnerProcess.runAll(selectedProject);
+		this.testRunnerProcess.runAll(folder);
 	},
 	deactivate() {
 		this.subscriptions.dispose();

--- a/lib/test-runner-process.js
+++ b/lib/test-runner-process.js
@@ -1,4 +1,6 @@
 /** @babel */
+import fs from 'fs';
+
 import EventEmitter from 'events';
 import TerminalCommandExecutor from './terminal-command-executor';
 import ParserFactory from './parser-factory';
@@ -29,11 +31,27 @@ export default class TestRunnerProcess extends EventEmitter {
 		const context = new ExecutionContext();
 		context.setSingleFile(file);
 
-		this._runCommand('ava', [file, '--tap'], folder, context);
+		const ava = this._getAvaInstance(folder);
+
+		this._runCommand(ava, [file, '--tap'], folder, context);
 	}
 
 	runAll(folder) {
-		this._runCommand('ava', ['--tap'], folder, new ExecutionContext());
+		const ava = this._getAvaInstance(folder);
+
+		this._runCommand(ava, ['--tap'], folder, new ExecutionContext());
+	}
+
+	_getAvaInstance(path) {
+		let projectPath = Array.isArray(path) ? path[0] : path;
+		projectPath = atom.project.relativizePath(projectPath)[0];
+		const projectAva = `${projectPath}/node_modules/.bin/ava`;
+
+		if (projectPath && fs.existsSync(projectAva)) {
+			return projectAva;
+		}
+
+		return 'ava';
 	}
 
 	_runCommand(command, args, folder, context) {


### PR DESCRIPTION
Closes https://github.com/avajs/atom-ava/issues/19

It's all explained in the commits, but to provide a quick summary: This package uses the global AVA. From the previously mentioned issue, it seems AVA is smart enough to know how to find local installations of AVA closest to the given file/folder. However, in cases where you don't have any global packages, this will simply fail.

This MR adds a default behaviour of trying to use the project AVA, if installed. Otherwise, if not available, it will fallback to the globally installed AVA.