### PR TITLE
Wrap long test name lines

### DIFF
--- a/styles/ava.less
+++ b/styles/ava.less
@@ -61,10 +61,10 @@
 		padding: 10px 30px;
 
 		.test {
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
 			font-size: 12px;
+			text-indent: -1em;
+			margin-bottom: 2px;
+			margin-left: 0.5em;
 		}
 
 		.ok {


### PR DESCRIPTION
Previously a long test name would simply be cut off with `...`. Example here:

![atom-ava-old-style](https://user-images.githubusercontent.com/11218602/66269140-3ae53c80-e845-11e9-86bd-527be5347bea.png)

With this MR long test names would simply be wrapped with an indent for anything but the first line:

![atom-ava-new-style](https://user-images.githubusercontent.com/11218602/66269145-56e8de00-e845-11e9-88ea-12433c2b10b5.png)

---

Personally I don't like the cutting off behaviour, and I'd much prefer atom-ava to display the whole name and just use as much vertical space as needed if it doesn't fit a single line. That being said, CSS and design is _really_ not my forte, so I'm open to any CSS changes that might make it look prettier. I'm still not entirely convinced on the indent, so I'm open to changes.